### PR TITLE
Add autoindex_format directive

### DIFF
--- a/grammars/nginx.cson
+++ b/grammars/nginx.cson
@@ -74,7 +74,7 @@
     'name': 'constant.language.module.http.auth_basic'
   }
   {
-    'match': '\\b(autoindex|autoindex_exact_size|autoindex_localtime)\\b'
+    'match': '\\b(autoindex|autoindex_exact_size|autoindex_localtime|autoindex_format)\\b'
     'name': 'constant.language.module.http.autoindex'
   }
   {


### PR DESCRIPTION
New in nginx 1.7.9: http://nginx.org/en/docs/http/ngx_http_autoindex_module.html